### PR TITLE
Fixed detection of -loops arg

### DIFF
--- a/MeleeMedia/Audio/HPS.cs
+++ b/MeleeMedia/Audio/HPS.cs
@@ -45,7 +45,7 @@ namespace MeleeMedia.Audio
                     channel.Gain = r.ReadInt16();
                     channel.InitialPredictorScale = r.ReadInt16();
                     channel.InitialSampleHistory1 = r.ReadInt16();
-                    channel.InitialSampleHistory1 = r.ReadInt16();
+                    channel.InitialSampleHistory2 = r.ReadInt16();
 
                     channel.NibbleCount = EA - CA;
                     channel.LoopStart = SA - CA;

--- a/MeleeMedia/Program.cs
+++ b/MeleeMedia/Program.cs
@@ -16,7 +16,7 @@ namespace MeleeMedia
                 var outf = args[1];
 
                 string loopPoint = "00:00:00";
-                for (int i = 0; i > args.Length - 1; i++)
+                for (int i = 0; i < args.Length - 1; i++)
                 {
                     if (args[i] == "-loop")
                         loopPoint = args[i + 1];


### PR DESCRIPTION
The "-loop" argument wasn't being detected, due to a reversed comparator in the for-loop for argument parsing.